### PR TITLE
test: 청원 관련 기능 테스트 추가

### DIFF
--- a/src/main/kotlin/com/example/echo/domain/petition/dto/request/PetitionRequestDto.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/dto/request/PetitionRequestDto.kt
@@ -17,7 +17,7 @@ data class PetitionRequestDto(
     val content: String,
 
     @Schema(description = "청원 요약", example = "독도 보호에 대한 간략한 요약")
-    val summary: String,
+    val summary: String? = null,
 
     @Schema(description = "청원 시작일", example = "2024-10-01T00:00:00")
     val startDate: LocalDateTime,
@@ -32,7 +32,7 @@ data class PetitionRequestDto(
     val originalUrl: String,
 
     @Schema(description = "관련 뉴스", example = "https://www.newspenguin.com/news/articleView.html?idxno=16159")
-    val relatedNews: String
+    val relatedNews: String? = null
 ) {
     fun toEntity(member: Member): Petition {
         return Petition(
@@ -49,19 +49,17 @@ data class PetitionRequestDto(
     }
 
     fun toEntityWithExistingData(existingPetition: Petition, member: Member): Petition {
-        return Petition(
-            member = member,
-            title = this.title,
-            content = this.content,
-            summary = this.summary,
-            startDate = this.startDate,
-            endDate = this.endDate,
-            category = this.category,
-            originalUrl = this.originalUrl,
-            relatedNews = this.relatedNews,
-            likesCount = existingPetition.likesCount,
-            interestCount = existingPetition.interestCount,
-            agreeCount = existingPetition.agreeCount
-        )
+        existingPetition.member = member
+        existingPetition.title = this.title
+        existingPetition.content = this.content
+        existingPetition.summary = this.summary
+        existingPetition.startDate = this.startDate
+        existingPetition.endDate = this.endDate
+        existingPetition.category = this.category
+        existingPetition.originalUrl = this.originalUrl
+        existingPetition.relatedNews = this.relatedNews
+
+        // likesCount, interestCount, agreeCount는 기존값 유지
+        return existingPetition
     }
 }

--- a/src/main/kotlin/com/example/echo/domain/petition/entity/Petition.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/entity/Petition.kt
@@ -10,13 +10,11 @@ import java.time.LocalDateTime
 class Petition(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-
     @Column(name = "petition_id")
     val petitionId: Long? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
-
     var member: Member? = null,
 
     @Column(name = "title", nullable = false, length = 1000)
@@ -29,7 +27,6 @@ class Petition(
     var summary: String? = null,
 
     @Column(name = "start_date", nullable = false)
-
     var startDate: LocalDateTime? = null,
 
     @Column(name = "end_date", nullable = false)
@@ -51,9 +48,7 @@ class Petition(
     @Column(name = "interest_count")
     var interestCount: Int = 0,
 
-
     @Column(name = "agree_count") // 청원 객체 생성 시점엔 동의자수 크롤링 데이터를 받아오지 않아 nullable = true 설정
-
     var agreeCount: Int? = null,
 
     @ElementCollection

--- a/src/main/kotlin/com/example/echo/domain/petition/service/AgreeCountMonitoringService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/AgreeCountMonitoringService.kt
@@ -13,7 +13,7 @@ class AgreeCountMonitoringService(
     private val petitionCrawlService: PetitionCrawlService
 ) {
     @Transactional
-//    @Scheduled(fixedRate = 600000L)   // 데이터가 삽입되기 이전엔 주석 처리
+    @Scheduled(fixedRate = 86400000L)   // 스케줄링 주기 하루로 설정
     fun updateAgreeCountFromWeb() {
         val petitions = petitionRepository.findAllActive()
 

--- a/src/main/kotlin/com/example/echo/domain/petition/service/PetitionService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/PetitionService.kt
@@ -45,7 +45,7 @@ class PetitionService (
         // 청원 기간 만료 체크 -> 따로 서비스 층에 작성
         //  위에서 exception 발생 안함 = 청원이 존재한다는 뜻 -> 단순 날짜 비교만 진행
         if (isExpired(petition)) { // 만료되었으면 예외 발생
-            throw PetitionCustomException(ErrorCode.PETITION_NOT_FOUND)
+            throw PetitionCustomException(ErrorCode.PETITION_EXPIRED)
         }
 
         val summary = petition.summary // 요약 내용 체크

--- a/src/main/kotlin/com/example/echo/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/echo/global/exception/ErrorCode.kt
@@ -24,6 +24,7 @@ enum class ErrorCode(
 
     // Petition
     PETITION_NOT_FOUND(NOT_FOUND, "청원을 찾을 수 없습니다."),
+    PETITION_EXPIRED(NOT_FOUND, "청원 만료 기간이 지났습니다."),
     SELENIUM_TIMEOUT(BAD_REQUEST, "크롤링 도중 시간 초과가 발생했습니다."),
     SELENIUM_NO_ELEMENT_FOUND(NOT_FOUND, "페이지에서 필요한 요소를 찾을 수 없습니다."),
     SELENIUM_UNKNOWN_ERROR(INTERNAL_SERVER_ERROR, "알 수 없는 크롤링 오류가 발생했습니다."),

--- a/src/main/kotlin/com/example/echo/global/exception/PetitionCustomException.kt
+++ b/src/main/kotlin/com/example/echo/global/exception/PetitionCustomException.kt
@@ -1,5 +1,5 @@
 package com.example.echo.global.exception
 
 class PetitionCustomException(
-    private val errorCode: ErrorCode
+    val errorCode: ErrorCode
 ) : RuntimeException(errorCode.message)

--- a/src/test/kotlin/com/example/echo/domain/petition/repository/PetitionRepositoryTests.kt
+++ b/src/test/kotlin/com/example/echo/domain/petition/repository/PetitionRepositoryTests.kt
@@ -1,0 +1,185 @@
+package com.example.echo.domain.petition.repository
+
+import com.example.echo.domain.member.entity.Member
+import com.example.echo.domain.member.entity.Role
+import com.example.echo.domain.member.repository.MemberRepository
+import com.example.echo.domain.petition.entity.Category
+import com.example.echo.domain.petition.entity.Petition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+class PetitionRepositoryTests {
+
+    @Autowired
+    lateinit var petitionRepository: PetitionRepository
+
+    @Autowired
+    lateinit var memberRepository: MemberRepository
+
+    private var admin: Member? = null
+
+    @BeforeEach
+    fun setUp() {
+        admin = Member(
+            userId = "admin",
+            name = "김철수",
+            email = "admin@example.com",
+            password = "1111",
+            phone = "010-1111-1111",
+            role = Role.ADMIN
+        ).let {
+            memberRepository.save(it)
+        }
+
+        for (i in 0..4) {
+            petitionRepository.save(Petition().apply {
+                member = admin
+                title = "청원 제목 테스트 $i"
+                content = "청원 내용 테스트 $i"
+                startDate = LocalDateTime.now()
+                endDate = LocalDateTime.now().plusDays(30L + i)
+                category = Category.entries.toTypedArray()[i]
+                originalUrl = "https://petitions.sample/$i"
+                likesCount = i
+            })
+        }
+    }
+
+    @Test
+    @DisplayName("특정 카테고리의 청원 목록 페이징 조회 테스트")
+    fun findByCategoryTest() {
+        val pageable = PageRequest.of(0, 2)
+        val category = Category.POLITICS
+
+        val page = petitionRepository.findByCategory(pageable, category)
+
+        assertEquals(1, page.totalElements, "페이징한 청원의 수는 1")
+        assertEquals(category, page.content.firstOrNull()?.category, "해당 청원 카테고리는 ${category.description}.")
+    }
+
+    @Test
+    @DisplayName("DB에 없는 카테고리로 청원 목록 페이징 조회 시 실패")
+    fun findByCategoryTestFail() {
+        val pageable = PageRequest.of(0, 2)
+        val wrongCategory = Category.OTHERS
+
+        val page = petitionRepository.findByCategory(pageable, wrongCategory)
+
+        assertEquals(0, page.totalElements, "잘못된 카테고리로 조회했을 때 청원의 수는 0")
+    }
+
+    @Test
+    @DisplayName("주어진 originalUrl에 해당하는 청원 수 조회")
+    fun findByUrlTest() {
+        val url = "https://petitions.sample/0"
+        val wrongUrl = "https://petitions.sample/100"
+
+        assertEquals(1, petitionRepository.findByUrl(url))
+        assertEquals(0, petitionRepository.findByUrl(wrongUrl))
+    }
+
+    @Test
+    @DisplayName("청원 만료일 순 5개 조회 - 첫 번째 청원의 종료 날짜가 마지막 청원의 종료 날짜보다 4일 이전이어야 함")
+    fun getEndDatePetitionsTest() {
+        val pageable = PageRequest.of(0, 5)
+
+        val petitions = petitionRepository.getEndDatePetitions(pageable)
+
+        assertEquals(5, petitions.size)
+
+        val firstEndDate = petitions.first().endDate!!.toLocalDate()
+        val lastEndDate = petitions.last().endDate!!.toLocalDate()
+
+        assertThat(firstEndDate).isEqualTo(lastEndDate.minusDays(4))
+    }
+
+    @Test
+    @DisplayName("청원 좋아요 순 5개 조회 - 첫 번째 청원의 좋아요 수가 마지막 청원의 좋아오 수보다 4 커야 함")
+    fun getLikesCountPetitionsTest() {
+        val pageable = PageRequest.of(0, 5)
+
+        val petitions = petitionRepository.getLikesCountPetitions(pageable)
+
+        assertEquals(5, petitions.size)
+
+        val firstLikesCount = petitions.first().likesCount!!
+        val lastLikesCount = petitions.last().likesCount!!
+
+        assertThat(firstLikesCount).isEqualTo(lastLikesCount + 4)
+    }
+
+    @Test
+    @DisplayName("카테고리 선택 시 해당 카테고리 청원 5개 무작위 조회")
+    fun getCategoryPetitionsInRandomOrderTest() {
+        for (i in 0..9) {
+            petitionRepository.save(Petition().apply {
+                member = admin
+                title = "청원 제목 테스트 $i"
+                content = "청원 내용 테스트 $i"
+                startDate = LocalDateTime.now()
+                endDate = LocalDateTime.now().plusDays(30L + i)
+                category = Category.POLITICS
+                originalUrl = "https://petitions.sample/$i"
+                likesCount = i
+            })
+        }
+        val pageable = PageRequest.of(0, 5)
+
+        val petitions = petitionRepository.getCategoryPetitionsInRandomOrder(Category.POLITICS, pageable)
+
+        assertEquals(5, petitions.size)
+        assertTrue(petitions.all { petition -> petition.category == Category.POLITICS })
+    }
+
+    @Test
+    @DisplayName("제목이 특정 문자열을 포함하는 청원 조회 테스트")
+    fun findByTitleContainingIgnoreCaseTest() {
+        petitionRepository.save(Petition().apply {
+            member = admin
+            title = "특정 제목 테스트"
+            content = "청원 내용 테스트"
+            startDate = LocalDateTime.now()
+            endDate = LocalDateTime.now().plusDays(30)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/specific"
+            likesCount = 5
+        })
+
+        val petitions = petitionRepository.findByTitleContainingIgnoreCase("특정")
+
+        assertEquals(1, petitions.size)
+        assertTrue(petitions.all { it.title!!.contains("특정", ignoreCase = true) })
+    }
+
+    @Test
+    @DisplayName("진행 중인 청원 목록 조회 테스트")
+    fun findAllOngoingTest() {
+        val pageable = PageRequest.of(0, 5)
+
+        val petitions = petitionRepository.findAllOngoing(pageable)
+
+        assertTrue(petitions.totalElements > 0)
+        assertTrue(petitions.content.all { it.endDate!!.isAfter(LocalDateTime.now()) })
+    }
+
+    @Test
+    @DisplayName("모든 진행 중인 청원 조회 테스트")
+    fun findAllActiveTest() {
+        val activePetitions = petitionRepository.findAllActive()
+
+        assertTrue(activePetitions.all { it.endDate!!.isAfter(LocalDateTime.now()) })
+    }
+}

--- a/src/test/kotlin/com/example/echo/domain/petition/service/PetitionServiceTests.kt
+++ b/src/test/kotlin/com/example/echo/domain/petition/service/PetitionServiceTests.kt
@@ -1,0 +1,422 @@
+package com.example.echo.domain.petition.service
+
+import com.example.echo.domain.member.entity.Member
+import com.example.echo.domain.member.entity.Role
+import com.example.echo.domain.member.repository.MemberRepository
+import com.example.echo.domain.petition.dto.request.PetitionRequestDto
+import com.example.echo.domain.petition.entity.Category
+import com.example.echo.domain.petition.entity.Petition
+import com.example.echo.domain.petition.repository.PetitionRepository
+import com.example.echo.global.exception.ErrorCode
+import com.example.echo.global.exception.PetitionCustomException
+import com.example.echo.log
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = ["classpath:application-test.properties"])
+class PetitionServiceTests {
+
+    @Autowired
+    lateinit var petitionRepository: PetitionRepository
+
+    @Autowired
+    lateinit var petitionService: PetitionService
+
+    @Autowired
+    lateinit var memberRepository: MemberRepository
+
+    private var admin: Member? = null
+    private var request: PetitionRequestDto? = null
+
+    @BeforeEach
+    fun setUp() {
+        admin = Member(
+            userId = "admin",
+            name = "김철수",
+            email = "admin@example.com",
+            password = "1111",
+            phone = "010-1111-1111",
+            role = Role.ADMIN
+        ).let {
+            memberRepository.save(it)
+        }
+
+        for (i in 0..4) {
+            petitionRepository.save(Petition().apply {
+                member = admin
+                title = "청원 제목 테스트 $i"
+                content = "청원 내용 테스트 $i"
+                startDate = LocalDateTime.now()
+                endDate = LocalDateTime.now().plusDays(30L + i)
+                category = Category.entries.toTypedArray()[i]
+                originalUrl = "https://petitions.sample/$i"
+                likesCount = i
+            })
+        }
+
+        request = PetitionRequestDto(
+            memberId = admin!!.memberId!!,
+            title = "청원 요청 제목 테스트",
+            content = "청원 요청 내용 테스트",
+            startDate = LocalDateTime.now(),
+            endDate = LocalDateTime.now().plusDays(30),
+            category = Category.POLITICS,
+            originalUrl = "https://petitions.sample/0"
+        )
+    }
+
+    @Test
+    @DisplayName("관리자가 청원을 등록할 경우, 청원 데이터는 총 6개")
+    fun createPetitionTest() {
+        val savedPetition = petitionService.createPetition(request!!)
+
+        assertEquals("청원 요청 제목 테스트", savedPetition.title)
+        assertEquals(6, petitionRepository.findAll().size)
+    }
+
+    @Test
+    @DisplayName("청원 단건 조회 - 요약이 없는 경우 요약 생성해서 반환")
+    fun getPetitionByIdNoSummaryTest() {
+        val petition = petitionRepository.save(Petition().apply {
+            member = admin
+            title = "청원 제목 테스트"
+            content = "청원 내용 테스트"
+            startDate = LocalDateTime.now()
+            endDate = LocalDateTime.now().plusDays(30L)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/i"
+            likesCount = 30
+        })
+
+        assertEquals("청원 제목 테스트", petition.title)
+        assertNotEquals("요약은 비어있지 않아야 합니다.", "", petition.summary)
+        log.info("요약 결과: ${petition.summary}")
+    }
+
+    @Test
+    @DisplayName("청원 단건 조회 - 요약이 있는 경우 요약 그대로 반환")
+    fun getPetitionByExistingSummaryTest() {
+        val summaryPetition = petitionRepository.save(Petition().apply {
+            member = admin
+            title = "요약 청원 제목 테스트"
+            content = "요약 청원 내용 테스트"
+            startDate = LocalDateTime.now()
+            endDate = LocalDateTime.now().plusDays(30L)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/10"
+            likesCount = 10
+            summary = "청원 요약 존재"
+        })
+
+        val foundPetition = petitionService.getPetitionById(summaryPetition.petitionId!!)
+
+        assertEquals("요약 청원 제목 테스트", foundPetition.title)
+        assertEquals("청원 요약 존재", foundPetition.summary)
+    }
+
+    @Test
+    @DisplayName("청원 단건 조회 - 해당 청원이 없는 경우 예외")
+    fun getPetitionByIdTestNotFound() {
+        val wrongPetitionId = 100L
+
+        val exception = assertThrows<PetitionCustomException> {
+            petitionService.getPetitionById(wrongPetitionId)
+        }
+
+        assertEquals(ErrorCode.PETITION_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    @DisplayName("청원 단건 조회 - 해당 청원 만료 기간이 지난 경우 예외")
+    fun getPetitionByIdTestExpired() {
+        val expiredPetition = petitionRepository.save(Petition().apply {
+            member = admin
+            title = "만료된 청원 제목 테스트"
+            content = "만료된 청원 내용 테스트"
+            startDate = LocalDateTime.now().minusDays(60L)
+            endDate = LocalDateTime.now().minusDays(30L)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/100"
+            likesCount = 100
+        })
+
+        val exception = assertThrows<PetitionCustomException> {
+            petitionService.getPetitionById(expiredPetition.petitionId!!)
+        }
+
+        assertEquals(ErrorCode.PETITION_EXPIRED, exception.errorCode)
+    }
+
+    @Test
+    @DisplayName("DB에 존재하는 모든 청원 전체 조회 페이징")
+    fun getPetitionsTest() {
+        val pageable = PageRequest.of(0, 10)
+
+        val page = petitionService.getPetitions(pageable)
+
+        assertEquals(5, page.totalElements)
+        assertEquals("청원 제목 테스트 0", page.first().title)
+        assertEquals("청원 제목 테스트 4", page.last().title)
+    }
+
+    @Test
+    @DisplayName("진행 중인 청원 전체 조회 페이징")
+    fun getOngoingPetitionsTest() {
+        petitionRepository.save(Petition().apply {
+            member = admin
+            title = "만료된 청원 제목 테스트"
+            content = "만료된 청원 내용 테스트"
+            startDate = LocalDateTime.now().minusDays(60L)
+            endDate = LocalDateTime.now().minusDays(30L)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/100"
+            likesCount = 100
+        })
+        val pageable = PageRequest.of(0, 10)
+
+        val page = petitionService.getOngoingPetitions(pageable)
+
+        assertEquals(6, petitionRepository.findAll().size)
+        assertEquals(5, page.totalElements, "만료된 청원은 제외하고 진행 중인 청원만 가져옵니다.")
+    }
+
+    @Test
+    @DisplayName("해당 카테고리 청원 전체 조회 페이징")
+    fun getPetitionsByCategoryTest() {
+        for (i in 21..29) {
+            petitionRepository.save(Petition().apply {
+                member = admin
+                title = "기타 청원 제목 테스트 $i"
+                content = "기타 청원 내용 테스트 $i"
+                startDate = LocalDateTime.now()
+                endDate = LocalDateTime.now().plusDays(30L)
+                category = Category.OTHERS
+                originalUrl = "https://petitions.sample/$i"
+                likesCount = i
+            })
+        }
+        val pageable = PageRequest.of(1, 5)
+
+        val page = petitionService.getPetitionsByCategory(pageable, Category.OTHERS)
+
+        assertEquals("기타 청원 제목 테스트 26", page.first().title)
+        assertEquals(Category.OTHERS, page.first().category)
+        assertEquals(9, page.totalElements)
+        assertEquals(4, page.content.size)
+    }
+
+    @Test
+    @DisplayName("청원 만료일 순 5개 조회 - 첫 번째 청원의 종료 날짜가 마지막 청원의 종료 날짜보다 4일 이전이어야 함")
+    fun endDatePetitionsTest() {
+        val petitions = petitionService.endDatePetitions
+
+        assertEquals(5, petitions.size)
+
+        val firstEndDate = petitions.first().endDate!!.toLocalDate()
+        val lastEndDate = petitions.last().endDate!!.toLocalDate()
+
+        assertThat(firstEndDate).isEqualTo(lastEndDate.minusDays(4))
+    }
+
+    @Test
+    @DisplayName("청원 좋아요 순 5개 조회 - 첫 번째 청원의 좋아요 수가 마지막 청원의 좋아오 수보다 4 커야 함")
+    fun likesCountPetitionsTest() {
+        val petitions = petitionService.likesCountPetitions
+
+        assertEquals(5, petitions.size)
+
+        val firstLikesCount = petitions.first().likesCount!!
+        val lastLikesCount = petitions.last().likesCount!!
+
+        assertThat(firstLikesCount).isEqualTo(lastLikesCount + 4)
+    }
+
+    @Test
+    @DisplayName("청원 좋아요 추가/제거 검증")
+    fun toggleLikeOnPetitionTest() {
+        val petition = petitionRepository.save(Petition().apply {
+            member = admin
+            title = "청원 제목 테스트 좋아요"
+            content = "청원 내용 테스트 좋아요"
+            startDate = LocalDateTime.now()
+            endDate = LocalDateTime.now().plusDays(30L)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/10"
+            likesCount = 4
+        })
+
+        assertEquals(4, petition.likesCount)
+        assertThat(petition.likedMemberIds).doesNotContain(admin!!.memberId!!)  // 좋아요 목록에 없는지 검증
+
+        val likeMessage = petitionService.toggleLikeOnPetition(petition.petitionId!!, admin!!.memberId!!)
+
+        assertEquals("좋아요가 추가되었습니다.", likeMessage)
+        assertEquals(5, petition.likesCount)
+        assertThat(petition.likedMemberIds).contains(admin!!.memberId!!) // 좋아요 추가 후 있는지 검증
+
+        val cancelMessage = petitionService.toggleLikeOnPetition(petition.petitionId!!, admin!!.memberId!!)
+
+        assertEquals("좋아요가 제거되었습니다.", cancelMessage)
+        assertEquals(4, petition.likesCount)
+        assertThat(petition.likedMemberIds).doesNotContain(admin!!.memberId!!)  // 좋아요 목록에 다시 없는지 검증
+    }
+
+    @Test
+    @DisplayName("카테고리 선택 시 해당 카테고리 청원 5개 무작위 조회")
+    fun getRandomCategoryPetitionsTest() {
+        for (i in 0..9) {
+            petitionRepository.save(Petition().apply {
+                member = admin
+                title = "청원 제목 테스트 $i"
+                content = "청원 내용 테스트 $i"
+                startDate = LocalDateTime.now()
+                endDate = LocalDateTime.now().plusDays(30L + i)
+                category = Category.POLITICS
+                originalUrl = "https://petitions.sample/$i"
+                likesCount = i
+            })
+        }
+
+        val petitions = petitionService.getRandomCategoryPetitions(Category.POLITICS)
+
+        assertEquals(5, petitions.size)
+        assertTrue(petitions.all { petition -> petition.category == Category.POLITICS })
+    }
+
+    @Test
+    @DisplayName("관리자 청원 수정")
+    fun updatePetitionTest() {
+        val petition = petitionRepository.save(Petition().apply {
+            member = admin
+            title = "청원 제목 테스트 수정"
+            content = "청원 내용 테스트 수정"
+            startDate = LocalDateTime.now()
+            endDate = LocalDateTime.now().plusDays(30L)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/10"
+            likesCount = 10
+        })
+
+        petitionService.updatePetition(petition.petitionId!!, request!!)
+
+        assertEquals("청원 요청 제목 테스트", petition.title)
+        assertNotEquals("청원 내용 테스트 0", petition.content, "새 요청 내용으로 변해야 합니다.")
+    }
+
+    @Test
+    @DisplayName("관리자 청원 수정 - 해당 청원이 없는 경우 예외 ")
+    fun updatePetitionTestNotFound() {
+        val wrongPetitionId = 1000L
+
+        val exception = assertThrows<PetitionCustomException> {
+            petitionService.updatePetition(wrongPetitionId, request!!)
+        }
+
+        assertEquals(ErrorCode.PETITION_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    @DisplayName("관리자 청원 삭제")
+    fun deletePetitionByIdTest() {
+        val petition = petitionRepository.save(Petition().apply {
+            member = admin
+            title = "청원 제목 테스트 삭제"
+            content = "청원 내용 테스트 삭제"
+            startDate = LocalDateTime.now()
+            endDate = LocalDateTime.now().plusDays(30L)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/10"
+            likesCount = 10
+        })
+
+        petitionService.deletePetitionById(petition.petitionId!!)
+
+        val exception = assertThrows<PetitionCustomException> {
+            petitionService.getPetitionById(petition.petitionId!!)
+        }
+
+        assertEquals(ErrorCode.PETITION_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    @DisplayName("관리자 청원 삭제 - 해당 청원이 없는 경우 예외")
+    fun deletePetitionByIdTestNotFound() {
+        val wrongPetitionId = 100L
+
+        val exception = assertThrows<PetitionCustomException> {
+            petitionService.deletePetitionById(wrongPetitionId)
+        }
+
+        assertEquals(ErrorCode.PETITION_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    @DisplayName("청원 만료일이 지났는지 검증 - 만료일 남은 경우")
+    fun isExpiredTestValid() {
+        val petition = petitionRepository.save(Petition().apply {
+            member = admin
+            title = "청원 제목 테스트 좋아요"
+            content = "청원 내용 테스트 좋아요"
+            startDate = LocalDateTime.now()
+            endDate = LocalDateTime.now().plusDays(30L)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/10"
+            likesCount = 4
+        })
+
+        val validPetition = petitionRepository.findByIdOrNull(petition.petitionId)
+            ?: throw PetitionCustomException(ErrorCode.PETITION_NOT_FOUND)
+
+        val isExpired = petitionService.isExpired(validPetition)
+
+        assertFalse(isExpired, "청원이 아직 만료되지 않았어야 합니다.")
+    }
+
+    @Test
+    @DisplayName("청원 만료일이 지났는지 검증 - 만료일 지난 경우")
+    fun isExpiredTestExpired() {
+        val expiredPetition = petitionRepository.save(Petition().apply {
+            member = admin
+            title = "만료된 청원 제목 테스트"
+            content = "만료된 청원 내용 테스트"
+            startDate = LocalDateTime.now().minusDays(60L)
+            endDate = LocalDateTime.now().minusDays(30L)
+            category = Category.POLITICS
+            originalUrl = "https://petitions.sample/100"
+            likesCount = 100
+        })
+
+        val isExpired = petitionService.isExpired(expiredPetition)
+
+        assertTrue(isExpired, "청원이 만료 상태여야 합니다.")
+    }
+
+    @Test
+    @DisplayName("해당 키워드가 제목에 존재하는 청원 검색")
+    fun searchPetitionsByTitleTest() {
+        val petitions = petitionService.searchPetitionsByTitle("제목 테스트")
+
+        assertEquals(5, petitions.size)
+
+        val petition = petitionService.searchPetitionsByTitle("테스트 0")
+
+        assertEquals(1, petition.size)
+        assertEquals("청원 내용 테스트 0", petition.first().content)
+    }
+}


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

청원 Service, Repository에 구현된 커스텀 메서드에 대한 테스트 코드입니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

1. 기존 주석 처리 되어있던 동의자수 업데이트 스케줄링 기능을 추가하고, 주기는 하루로 변경
2. PetitionCustomException의 errorCode에 접근하기 위해 접근제한자 수정
3. PetitionRequestDto 수정
    - 항상 summary를 null 값이 아닌 값으로 넣게되어 요약 API를 사용할 수 없기 때문에, 기본값 null 부여
    - 청원 수정 기능인 toEntityWithExistingData()가 새로운 청원 객체를 만들고 있던 코드 수정
4. H2 database 기반의 PetitionRepository / PetitionService / PetitionUtilService 테스트 코드 추가
    - PetitionRepositoryTests: 기본적인 Spring의 CRUD 테스트는 진행하지 않았고, @Query 메서드에 대한 테스트만 추가
    - PetitionUtilServiceTests: 통합 테스트를 진행하니, 기존의 크롤링 테스트에서 멤버를 1L로 가져오던 하드코딩 방식에서, 동적으로 생성된 관리자를 가져올 수 있도록 변경 / 청원 Database에 삽입까지 되었는지 테스트 코드 추가
    - PetitionServiceTests: PetitionService의 모든 기능 테스트 추가

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

테스트 결과:
![스크린샷 2024-11-01 오후 9 56 24](https://github.com/user-attachments/assets/bb65f6de-25f2-41b2-b7eb-b9d708e71529)

전부 통과하긴 했지만, 크롤링 테스트에서 가끔 실패합니다. 오늘 수업 시간에 얘기했던 빈 페이지에서 넘어가지 못하는 경우 발생..
