### PR TITLE
fix: DOM 렌더링 대기시간 추가로 Selenium StaleElementReferenceException 크롤링오류 해결

### DIFF
--- a/src/main/kotlin/com/example/echo/domain/petition/service/AgreeCountMonitoringService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/AgreeCountMonitoringService.kt
@@ -25,7 +25,7 @@ class AgreeCountMonitoringService(
                     log.info("웹의 동의자 수: $currentAgreeCount, 기존 동의 수: ${petition.agreeCount}")
                     petition.agreeCount = currentAgreeCount
                     petitionRepository.save(petition)
-                    log.info("동의 수 업데이터 성공 청원: ${petition.petitionId}")
+                    log.info("동의 수 업데이트 성공 청원: ${petition.petitionId}")
                 } else if (currentAgreeCount < petition.agreeCount!!) {
                     log.info("동의 수 업데이트 실패")
                 } else {

--- a/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
@@ -189,9 +189,13 @@ class PetitionCrawlService(
     ).click()
 
     // 페이지가 완전히 로드될 때까지 대기
-    private fun waitForPageLoad() = wait.until {
-        (driver as JavascriptExecutor).executeScript("return document.readyState") == "complete"
+    private fun waitForPageLoad() {
+        wait.until {
+            (driver as JavascriptExecutor).executeScript("return document.readyState") == "complete"
+        }
+        Thread.sleep(500)
     }
+
 
     // 상세 페이지에서 청원 내용을 가져와서 주어진 PetitionCrawlResponse에 설정
     private fun setContentFromDetailPage(response: PetitionCrawlResponse) {

--- a/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
@@ -193,6 +193,7 @@ class PetitionCrawlService(
         wait.until {
             (driver as JavascriptExecutor).executeScript("return document.readyState") == "complete"
         }
+        // 추가로 500ms 대기
         Thread.sleep(500)
     }
 


### PR DESCRIPTION
## 📌 과제 설명
#22 feat: Redis 캐시 도입
## 👩‍💻 요구 사항과 구현 내용
- PetitionCrawlService 클래스의 waitForLoad 메서드에 추가 대기 시간(0.5초)을 설정하여 동적 컨텐츠가 로드되는 시간을 확보하였습니다.
- AgreeCountMonitoringService 클래스 updateAgreeCountFromWeb 메서드의 로그 메시지 오타 수정
## ✅ PR 포인트 & 궁금한 점
- 크롤링 과정에서 모든 청원 조회 이후, 청원을 요약하지 못하는 오류를 해결하였습니다.
- 크롤링으로 청원을 최신 상태로 자동 업데이트하는 과정에서 일부 청원의 업데이트가 실패하는 오류를 해결하였습니다.
