### PR TITLE
feat: Redis 캐시 조회 기능 추가, 조회 성능 개선

### DIFF
--- a/src/main/kotlin/com/example/echo/domain/petition/controller/PetitionController.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/controller/PetitionController.kt
@@ -75,7 +75,7 @@ class PetitionController (
     @GetMapping("/view/likesCount")
     @Operation(summary = "청원 좋아요 수 기준 조회", description = "좋아요 수가 많은 청원 5개를 조회합니다.")
     fun getLikesCountPetitions(): ResponseEntity<ApiResponse<List<PetitionResponseDto>>> {
-        val likesCountPetitions = petitionService.likesCountPetitions
+        val likesCountPetitions = petitionService.getLikesCountPetitions()
         return ResponseEntity.ok(ApiResponse.success(likesCountPetitions))
     }
 

--- a/src/main/kotlin/com/example/echo/domain/petition/dto/response/PetitionResponseDto.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/dto/response/PetitionResponseDto.kt
@@ -3,9 +3,10 @@ package com.example.echo.domain.petition.dto.response
 import com.example.echo.domain.petition.entity.Category
 import com.example.echo.domain.petition.entity.Petition
 import io.swagger.v3.oas.annotations.media.Schema
+import java.io.Serializable
 import java.time.LocalDateTime
 
-class PetitionResponseDto (petition: Petition){
+class PetitionResponseDto (petition: Petition) : Serializable{
     @Schema(description = "청원의 ID", example = "1")
     var petitionId: Long? = null
 
@@ -39,5 +40,9 @@ class PetitionResponseDto (petition: Petition){
         this.likesCount = petition.likesCount
         this.interestCount = petition.interestCount
         this.agreeCount = petition.agreeCount
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L  // serialVersionUID 추가
     }
 }

--- a/src/main/kotlin/com/example/echo/domain/petition/service/AgreeCountMonitoringService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/AgreeCountMonitoringService.kt
@@ -25,7 +25,7 @@ class AgreeCountMonitoringService(
                     log.info("웹의 동의자 수: $currentAgreeCount, 기존 동의 수: ${petition.agreeCount}")
                     petition.agreeCount = currentAgreeCount
                     petitionRepository.save(petition)
-                    log.info("동의 수 업데이터 성공 청원: ${petition.petitionId}")
+                    log.info("동의 수 업데이트 성공 청원: ${petition.petitionId}")
                 } else if (currentAgreeCount < petition.agreeCount!!) {
                     log.info("동의 수 업데이트 실패")
                 } else {

--- a/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
@@ -189,9 +189,13 @@ class PetitionCrawlService(
     ).click()
 
     // 페이지가 완전히 로드될 때까지 대기
-    private fun waitForPageLoad() = wait.until {
-        (driver as JavascriptExecutor).executeScript("return document.readyState") == "complete"
+    private fun waitForPageLoad() {
+        wait.until {
+            (driver as JavascriptExecutor).executeScript("return document.readyState") == "complete"
+        }
+        Thread.sleep(500)
     }
+
 
     // 상세 페이지에서 청원 내용을 가져와서 주어진 PetitionCrawlResponse에 설정
     private fun setContentFromDetailPage(response: PetitionCrawlResponse) {

--- a/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
@@ -193,6 +193,7 @@ class PetitionCrawlService(
         wait.until {
             (driver as JavascriptExecutor).executeScript("return document.readyState") == "complete"
         }
+        // 추가로 500ms 대기
         Thread.sleep(500)
     }
 

--- a/src/main/kotlin/com/example/echo/domain/petition/service/PetitionService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/PetitionService.kt
@@ -9,6 +9,7 @@ import com.example.echo.domain.petition.entity.Petition
 import com.example.echo.domain.petition.repository.PetitionRepository
 import com.example.echo.global.exception.ErrorCode
 import com.example.echo.global.exception.PetitionCustomException
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -73,6 +74,11 @@ class PetitionService (
 
 
     // 진행 중인 청원 전체 조회
+    @Cacheable(
+        cacheNames = arrayOf("ongoingPetitions"),
+        // petitions 테이블의 페이지 번호와 사이즈를 Redis의 key로 사용
+        key = "'petitions:page:' + #pageable.pageNumber + ':size:' + #pageable.pageSize"
+    )
     fun getOngoingPetitions(pageable: Pageable): Page<PetitionResponseDto> {
         return petitionRepository.findAllOngoing(pageable).map { PetitionResponseDto(it)}
     }
@@ -90,12 +96,15 @@ class PetitionService (
             return petitionRepository.getEndDatePetitions(pageable)
         }
 
-    val likesCountPetitions: List<PetitionResponseDto>
-        // 청원 동의자 순 5개 조회
-        get() {
-            val pageable: Pageable = PageRequest.of(0, 5)
-            return petitionRepository.getLikesCountPetitions(pageable)
-        }
+    // 청원 동의자 순 5개 조회
+    @Cacheable(
+        cacheNames = arrayOf("topLikedPetitions"),
+        key = "'petitions:likes'"
+    )
+    fun getLikesCountPetitions(): List<PetitionResponseDto> {
+        val pageable: Pageable = PageRequest.of(0, 5)
+        return petitionRepository.getLikesCountPetitions(pageable)
+    }
 
     // 좋아요 기능
     @Transactional

--- a/src/main/kotlin/com/example/echo/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/example/echo/global/config/RedisCacheConfig.kt
@@ -32,8 +32,6 @@ class RedisCacheConfig {
                     Jackson2JsonRedisSerializer(Object::class.java)
                 )
             )
-            // 데이터의 만료기간(TTL) 설정
-            .entryTtl(Duration.ofMinutes(1L))
 
         return RedisCacheManager
             .RedisCacheManagerBuilder

--- a/src/main/kotlin/com/example/echo/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/example/echo/global/config/RedisCacheConfig.kt
@@ -1,0 +1,44 @@
+package com.example.redisinspring.config
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching // Spring Boot의 캐싱 설정을 활성화
+class RedisCacheConfig {
+
+    @Bean
+    fun boardCacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val redisCacheConfiguration = RedisCacheConfiguration
+            .defaultCacheConfig()
+            // Redis에 Key를 저장할 때 String으로 직렬화(변환)해서 저장
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    StringRedisSerializer()
+                )
+            )
+            // Redis에 Value를 저장할 때 Json으로 직렬화(변환)해서 저장
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    Jackson2JsonRedisSerializer(Object::class.java)
+                )
+            )
+            // 데이터의 만료기간(TTL) 설정
+            .entryTtl(Duration.ofMinutes(1L))
+
+        return RedisCacheManager
+            .RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/example/echo/global/config/RedisConfig.kt
+++ b/src/main/kotlin/com/example/echo/global/config/RedisConfig.kt
@@ -1,0 +1,23 @@
+package com.example.redisinspring.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+
+@Configuration
+class RedisConfig(
+    @Value("\${spring.data.redis.host}")
+    private val host: String,
+
+    @Value("\${spring.data.redis.port}")
+    private val port: Int
+) {
+    @Bean
+    fun redisConnectionFactory(): LettuceConnectionFactory {
+        // Lettuce라는 라이브러리를 활용해 Redis 연결을 관리하는 객체를 생성하고
+        // Redis 서버에 대한 정보(host, port)를 설정한다.
+        return LettuceConnectionFactory(RedisStandaloneConfiguration(host, port))
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,3 +39,10 @@ spring.profiles.include=db
 # Redis ??
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
+# Redis Cache
+spring.cache.type=redis
+spring.cache.redis.time-to-live=120000
+logging.level.org.springframework.cache=TRACE
+logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} \
+  %clr(%5p) ${PID:- } --- [%15.15t] \
+  %clr(%-40.40logger{39}){cyan} : %replace(%msg){'Creating cache entry for', '[========== CACHE MISS ==========] Creating cache entry for'}%n

--- a/src/test/kotlin/com/example/echo/domain/petition/service/PetitionServiceTests.kt
+++ b/src/test/kotlin/com/example/echo/domain/petition/service/PetitionServiceTests.kt
@@ -237,7 +237,7 @@ class PetitionServiceTests {
     @Test
     @DisplayName("청원 좋아요 순 5개 조회 - 첫 번째 청원의 좋아요 수가 마지막 청원의 좋아오 수보다 4 커야 함")
     fun likesCountPetitionsTest() {
-        val petitions = petitionService.likesCountPetitions
+        val petitions = petitionService.getLikesCountPetitions()
 
         assertEquals(5, petitions.size)
 


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
#30 feat: Redis 관련 설정 추가, 캐싱 기능 추가
## 👩‍💻 요구 사항과 구현 내용
- 반복 조회 빈도가 높은 전체 청원 조회, 좋아요 순 청원 조회에 캐싱 기능 추가
- Cache-Aside 읽기 전략 적용 :
  - Redis 캐시에 key 존재 -> Cache Hit
  - key 없음 -> Cache Miss
- Write-Around 쓰기 전략 적용 :
  - 모든 데이터는 DB(MySQL)에 저장
  - Cache Miss가 발생하는 경우에만 DB, 캐시에 데이터 저장
  - 데이터 정합성 고려 : TTL(Time to Live) 설정
- 성능 개선 테스트 완료 - Grafana K6 부하 테스트 : 10초 동안 20239개 요청 처리 -> 29220개 요청 처리
  - 로컬 서버에 청원 전체 조회 요청
    - Redis 캐시 미적용 : 1초당 2012개 요청 처리
    - Redis 캐시 적용 : 1초당 2917개 요청 처리
![image](https://github.com/user-attachments/assets/3f54d2bb-6c41-460e-94ac-4db2fa69e4e6)
![image](https://github.com/user-attachments/assets/5154bdb6-3409-43d9-8f12-c4d2d919f5be)
![image](https://github.com/user-attachments/assets/21fe40ba-f59d-4314-bd54-808e2e64e010)
## ✅ Redis 설치 및 사용
- notion -> 문서에 관련 링크와 설명 첨부했습니다.
## ✅ PR 포인트 & 궁금한 점
- 조회 성능 44% 개선