### PR TITLE
Feat : Naver search api 연결 #15

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,8 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
 }
 
 kotlin {

--- a/src/main/kotlin/com/example/echo/EchoApplication.kt
+++ b/src/main/kotlin/com/example/echo/EchoApplication.kt
@@ -3,6 +3,7 @@ package com.example.echo
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableJpaAuditing
 @EnableScheduling
 @EnableCaching
+@ConfigurationPropertiesScan
 class EchoApplication
 
 inline var <reified T> T.log : Logger

--- a/src/main/kotlin/com/example/echo/domain/petition/controller/NewsSearchController.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/controller/NewsSearchController.kt
@@ -1,0 +1,99 @@
+package com.example.echo.domain.petition.controller
+
+import org.springframework.web.bind.annotation.*
+import org.springframework.http.ResponseEntity
+import com.example.echo.domain.petition.service.NewsSearchService
+import com.example.echo.domain.petition.dto.request.NewsSearchRequest
+import com.example.echo.domain.petition.dto.response.NewsResponseDto
+import com.example.echo.domain.petition.dto.response.PetitionDetailResponseDto
+import com.example.echo.domain.petition.entity.Petition
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.access.prepost.PreAuthorize
+
+@RestController
+@RequestMapping("/api/v1/search")
+@Tag(name = "News Controller", description = "뉴스 관리 API")
+class NewsSearchController(
+    private val newsSearchService: NewsSearchService
+) {
+
+    @GetMapping("/news")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "뉴스 검색 및 저장", description = "검색어로 뉴스를 검색하고 결과를 DB에 저장합니다.")
+    fun searchNews(
+        @RequestParam query: String,
+        @RequestParam(required = false, defaultValue = "3") display: Int,
+        @RequestParam(required = false, defaultValue = "1") start: Int,
+        @RequestParam(required = false, defaultValue = "sim") sort: String
+    ): ResponseEntity<List<NewsResponseDto>> {
+        val result = newsSearchService.searchNews(
+            NewsSearchRequest(
+                query = query,
+                display = display,
+                start = start,
+                sort = NewsSearchRequest.SortType.fromValue(sort)
+                    ?: throw IllegalArgumentException("Invalid sort type: $sort")
+            )
+        )
+        return ResponseEntity.ok(result.map { NewsResponseDto.from(it) })
+    }
+
+
+    @GetMapping("/news/search")
+    @Operation(summary = "뉴스 검색", description = "검색어로 뉴스를 검색하고 결과를 반환합니다. (DB 저장하지 않음)")
+    fun searchNewsOnly(
+        @RequestParam query: String,
+        @RequestParam(required = false, defaultValue = "3") display: Int,
+        @RequestParam(required = false, defaultValue = "1") start: Int,
+        @RequestParam(required = false, defaultValue = "sim") sort: String
+    ): ResponseEntity<List<NewsResponseDto>> {
+        val result = newsSearchService.searchNewsOnly(
+            NewsSearchRequest(
+                query = query,
+                display = display,
+                start = start,
+                sort = NewsSearchRequest.SortType.fromValue(sort)
+                    ?: throw IllegalArgumentException("Invalid sort type: $sort")
+            )
+        )
+        return ResponseEntity.ok(result.map { NewsResponseDto.from(it) })
+    }
+
+
+    @Operation(
+        summary = "청원 제목으로 뉴스 검색 및 저장",
+        description = "청원의 제목으로 뉴스를 검색하고, 첫 번째 뉴스를 청원의 관련 뉴스로 저장합니다. 검색된 3개의 뉴스는 DB에 저장됩니다."
+    )
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/news/petition/{petitionId}")
+    fun searchNewsWithPetitionTitle(
+        @PathVariable petitionId: Long
+    ): ResponseEntity<List<NewsResponseDto>> {
+        val result = newsSearchService.searchAndSaveNewsForPetition(petitionId)
+        return ResponseEntity.ok(result.map { NewsResponseDto.from(it) })
+    }
+
+
+    @Operation(
+        summary = "청원의 관련 뉴스 변경",
+        description = "청원의 관련 뉴스를 이미 저장된 다른 뉴스로 변경합니다."
+    )
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/news/petition/{petitionId}/{newsId}")
+    fun updatePetitionNews(
+        @PathVariable petitionId: Long,
+        @PathVariable newsId: Long
+    ): ResponseEntity<PetitionDetailResponseDto> {
+        val updatedPetition = newsSearchService.updatePetitionWithExistingNews(petitionId, newsId)
+        return ResponseEntity.ok(PetitionDetailResponseDto(updatedPetition))
+    }
+
+
+    @Operation(summary = "저장된 뉴스 목록 조회", description = "DB에 저장된 모든 뉴스 목록을 조회합니다.")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/news/saved")
+    fun getSavedNews(): ResponseEntity<List<NewsResponseDto>> {
+        return ResponseEntity.ok(newsSearchService.getAllNews())
+    }
+}

--- a/src/main/kotlin/com/example/echo/domain/petition/dto/request/NewsSearchRequest.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/dto/request/NewsSearchRequest.kt
@@ -1,0 +1,24 @@
+package com.example.echo.domain.petition.dto.request
+
+data class NewsSearchRequest(
+    val query: String,
+    val display: Int = 10,
+    val start: Int = 1,
+    val sort: SortType = SortType.ACCURACY
+) {
+    init {
+        require(display in 1..100) { "display must be between 1 and 100" }
+        require(start in 1..1000) { "start must be between 1 and 1000" }
+    }
+
+    enum class SortType(val value: String) {
+        ACCURACY("sim"),
+        RECENT("date");
+
+        companion object {
+            fun fromValue(value: String): SortType? {
+                return values().find { it.value == value }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/example/echo/domain/petition/dto/response/NewsResponseDto.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/dto/response/NewsResponseDto.kt
@@ -1,0 +1,28 @@
+package com.example.echo.domain.petition.dto.response
+
+import com.example.echo.domain.petition.entity.News
+import java.time.ZonedDateTime
+
+data class NewsResponseDto(
+    val newsId: Long?,
+    val title: String,
+    val originalLink: String,
+    val link: String,
+    val description: String,
+    val publishedAt: ZonedDateTime,
+    val petitionId: Long?
+) {
+    companion object {
+        fun from(news: News): NewsResponseDto {
+            return NewsResponseDto(
+                newsId = news.newsId,
+                title = news.title,
+                originalLink = news.originalLink,
+                link = news.link,
+                description = news.description,
+                publishedAt = news.publishedAt,
+                petitionId = news.petition?.petitionId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/echo/domain/petition/dto/response/NewsSearchResponse.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/dto/response/NewsSearchResponse.kt
@@ -1,0 +1,59 @@
+package com.example.echo.domain.petition.dto.response
+
+import com.example.echo.domain.petition.entity.News
+import com.example.echo.domain.petition.entity.Petition
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+data class NewsSearchResponse(
+    @JsonProperty("lastBuildDate")
+    val lastBuildDate: String,
+    @JsonProperty("total")
+    val total: Int,
+    @JsonProperty("start")
+    val start: Int,
+    @JsonProperty("display")
+    val display: Int,
+    @JsonProperty("items")
+    val items: List<NewsItemDto>
+) {
+    fun toDomain(): List<News> {
+        return items.map { it.toDomain() }
+    }
+}
+
+data class NewsItemDto(
+    @JsonProperty("title")
+    val title: String,
+    @JsonProperty("originallink")
+    val originalLink: String,
+    @JsonProperty("link")
+    val link: String,
+    @JsonProperty("description")
+    val description: String,
+    @JsonProperty("pubDate")
+    val pubDate: String
+) {
+    fun toDomain(): News {
+        return News(
+            title = title.replace("<b>", "").replace("</b>", ""),
+            originalLink = originalLink,
+            link = link,
+            description = description.replace("<b>", "").replace("</b>", ""),
+            publishedAt = ZonedDateTime.parse(pubDate, DateTimeFormatter.RFC_1123_DATE_TIME),
+            petition = null
+        )
+    }
+
+    fun toDomain(petition: Petition?): News {
+        return News(
+            title = title.replace("<b>", "").replace("</b>", ""),
+            originalLink = originalLink,
+            link = link,
+            description = description.replace("<b>", "").replace("</b>", ""),
+            publishedAt = ZonedDateTime.parse(pubDate, DateTimeFormatter.RFC_1123_DATE_TIME),
+            petition = petition
+        )
+    }
+}

--- a/src/main/kotlin/com/example/echo/domain/petition/entity/News.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/entity/News.kt
@@ -1,0 +1,32 @@
+package com.example.echo.domain.petition.entity
+
+import jakarta.persistence.*
+import java.time.ZonedDateTime
+
+@Entity
+@Table(name = "news")
+class News(
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "news_id")
+    val newsId: Long? = null,
+
+    @Column(name = "title", nullable = false)
+    val title: String,
+
+    @Column(name = "original_link", nullable = false)
+    val originalLink: String,
+
+    @Column(name = "link", nullable = false)
+    val link: String,
+
+    @Column(name = "description", nullable = false)
+    val description: String,
+
+    @Column(name = "published_at", nullable = false)
+    val publishedAt: ZonedDateTime,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "petition_id")
+    val petition: Petition? = null
+)

--- a/src/main/kotlin/com/example/echo/domain/petition/entity/Petition.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/entity/Petition.kt
@@ -52,7 +52,11 @@ class Petition(
     var agreeCount: Int? = null,
 
     @ElementCollection
-    var likedMemberIds: MutableSet<Long> = mutableSetOf()
+    var likedMemberIds: MutableSet<Long> = mutableSetOf(),
+
+    @OneToMany(mappedBy = "petition")
+    val news: MutableList<News> = mutableListOf()
+
 ) {
     // 좋아요를 추가하거나 제거
     fun toggleLike(memberId: Long): Boolean {

--- a/src/main/kotlin/com/example/echo/domain/petition/repository/NewsRepository.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/repository/NewsRepository.kt
@@ -1,0 +1,6 @@
+package com.example.echo.domain.petition.repository
+
+import com.example.echo.domain.petition.entity.News
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NewsRepository : JpaRepository<News, Long>

--- a/src/main/kotlin/com/example/echo/domain/petition/service/NewsSearchService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/NewsSearchService.kt
@@ -32,7 +32,6 @@ class NewsSearchService(
         return newsRepository.saveAll(response.items.map { it.toDomain() })
     }
 
-    // 새로운 메서드 (검색만)
     fun searchNewsOnly(request: NewsSearchRequest): List<News> {
         val response = naverNewsSearchUtil.searchNews(
             query = request.query,
@@ -79,7 +78,6 @@ class NewsSearchService(
         }
     }
 
-    // 기존 청원에 저장된 뉴스 연결하는 메서드 추가
     @Transactional
     fun updatePetitionWithExistingNews(petitionId: Long, newsId: Long): Petition {
         val petition = petitionRepository.findById(petitionId)
@@ -92,7 +90,6 @@ class NewsSearchService(
         return petitionRepository.save(petition)
     }
 
-    // 저장된 뉴스 목록 조회
     @Transactional(readOnly = true)
     fun getAllNews(): List<NewsResponseDto> {
         return newsRepository.findAll()

--- a/src/main/kotlin/com/example/echo/domain/petition/service/NewsSearchService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/NewsSearchService.kt
@@ -1,0 +1,101 @@
+package com.example.echo.domain.petition.service
+
+import com.example.echo.domain.petition.dto.request.NewsSearchRequest
+import com.example.echo.domain.petition.dto.response.NewsResponseDto
+import com.example.echo.domain.petition.entity.News
+import com.example.echo.domain.petition.entity.Petition
+import com.example.echo.domain.petition.repository.NewsRepository
+import com.example.echo.domain.petition.repository.PetitionRepository
+import com.example.echo.domain.petition.util.NaverNewsSearchUtil
+import com.example.echo.global.config.NaverProperties
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class NewsSearchService(
+    private val naverProperties: NaverProperties,
+    private val naverNewsSearchUtil: NaverNewsSearchUtil,
+    private val newsRepository: NewsRepository,
+    private val petitionRepository: PetitionRepository,
+) {
+    @Transactional
+    fun searchNews(request: NewsSearchRequest): List<News> {
+        val response = naverNewsSearchUtil.searchNews(
+            query = request.query,
+            clientId = naverProperties.client.id,
+            clientSecret = naverProperties.client.secret,
+            display = request.display,
+            start = request.start,
+            sort = request.sort.value
+        )
+
+        return newsRepository.saveAll(response.items.map { it.toDomain() })
+    }
+
+    // 새로운 메서드 (검색만)
+    fun searchNewsOnly(request: NewsSearchRequest): List<News> {
+        val response = naverNewsSearchUtil.searchNews(
+            query = request.query,
+            clientId = naverProperties.client.id,
+            clientSecret = naverProperties.client.secret,
+            display = request.display,
+            start = request.start,
+            sort = request.sort.value
+        )
+
+        return response.items.map { it.toDomain() }
+    }
+
+    @Transactional
+    fun searchAndSaveNewsForPetition(petitionId: Long): List<News> {
+        // 1. 청원 조회
+        val petition = petitionRepository.findById(petitionId)
+            .orElseThrow { NoSuchElementException("Petition not found with id: $petitionId") }
+
+        // 2. 청원의 title을 검색어로 사용
+        val query = petition.title ?: throw IllegalStateException("Petition title is null")
+
+        // 3. 뉴스 검색
+        val response = naverNewsSearchUtil.searchNews(
+            query = query,
+            clientId = naverProperties.client.id,
+            clientSecret = naverProperties.client.secret,
+            display = 3
+        )
+
+        if (response.items.isNotEmpty()) {
+            // 각 뉴스에 petition 설정하여 저장
+            val savedNewsList = response.items.map {
+                it.toDomain(petition)
+            }.let { newsRepository.saveAll(it) }
+
+            // 첫 번째 뉴스 링크를 청원의 relatedNews에 저장
+            petition.relatedNews = savedNewsList.first().link
+            petitionRepository.save(petition)
+
+            return savedNewsList
+        } else {
+            throw NoSuchElementException("No news found for petition: $petitionId")
+        }
+    }
+
+    // 기존 청원에 저장된 뉴스 연결하는 메서드 추가
+    @Transactional
+    fun updatePetitionWithExistingNews(petitionId: Long, newsId: Long): Petition {
+        val petition = petitionRepository.findById(petitionId)
+            .orElseThrow { NoSuchElementException("Petition not found with id: $petitionId") }
+
+        val news = newsRepository.findById(newsId)
+            .orElseThrow { NoSuchElementException("News not found with id: $newsId") }
+
+        petition.relatedNews = news.link
+        return petitionRepository.save(petition)
+    }
+
+    // 저장된 뉴스 목록 조회
+    @Transactional(readOnly = true)
+    fun getAllNews(): List<NewsResponseDto> {
+        return newsRepository.findAll()
+            .map { NewsResponseDto.from(it) }
+    }
+}

--- a/src/main/kotlin/com/example/echo/domain/petition/util/NaverNewsSearchUtil.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/util/NaverNewsSearchUtil.kt
@@ -1,0 +1,43 @@
+package com.example.echo.domain.petition.util
+
+import com.example.echo.domain.petition.dto.response.NewsSearchResponse
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders  // 변경: java.net.http.HttpHeaders -> org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class NaverNewsSearchUtil(
+    private val restTemplate: RestTemplate
+) {
+    companion object {
+        private const val NAVER_OPEN_API_URL = "https://openapi.naver.com/v1/search/news.json"
+    }
+
+    fun searchNews(
+        query: String,
+        clientId: String,
+        clientSecret: String,
+        display: Int = 10,
+        start: Int = 1,
+        sort: String = "sim"
+    ): NewsSearchResponse {
+        val url = "$NAVER_OPEN_API_URL?query=$query&display=$display&start=$start&sort=$sort"
+
+        val headers = HttpHeaders()  // spring의 HttpHeaders 사용
+        headers.set("X-Naver-Client-Id", clientId)
+        headers.set("X-Naver-Client-Secret", clientSecret)
+
+        val httpEntity = HttpEntity<String>(headers)
+
+        val response = restTemplate.exchange(
+            url,
+            HttpMethod.GET,
+            httpEntity,
+            NewsSearchResponse::class.java
+        )
+
+        return response.body ?: throw RuntimeException("Failed to get news from Naver API")
+    }
+}

--- a/src/main/kotlin/com/example/echo/global/config/NaverProperties.kt
+++ b/src/main/kotlin/com/example/echo/global/config/NaverProperties.kt
@@ -1,0 +1,14 @@
+package com.example.echo.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.ConstructorBinding
+
+@ConfigurationProperties(prefix = "naver")
+data class NaverProperties @ConstructorBinding constructor(
+    val client: Client
+) {
+    data class Client(
+        val id: String,
+        val secret: String
+    )
+}

--- a/src/main/kotlin/com/example/echo/global/security/filter/JWTCheckFilter.kt
+++ b/src/main/kotlin/com/example/echo/global/security/filter/JWTCheckFilter.kt
@@ -59,6 +59,10 @@ class JWTCheckFilter(
             return true
         }
 
+        if (requestURI.startsWith("/api/v1/search")) {
+            return requestURI == "/api/v1/search/news/search"
+        }
+
         if (requestURI.startsWith("/api/petitions") && method.equals("GET", ignoreCase = true)) {
             return requestURI != "/api/petitions/Myinterest"
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,3 +39,8 @@ spring.profiles.include=db
 # Redis ??
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
+
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
+
+logging.level.org.springframework.web=TRACE
+logging.level.com.example.echo=DEBUG


### PR DESCRIPTION
## 📌 과제 설명 
청원 관련 뉴스 API 검색 및 저장 구현

## 👩‍💻 요구 사항과 구현 내용 
1) API 관련 설정
2) RequestParam을 이용한 검색 / 청원 id를 통해 해당 제목을 검색어로 하여 뉴스 검색 및 저장
3) admin 권한 설정

## ✅ PR 포인트 & 궁금한 점 
1) application-db.properties에 api key 저장 필요 -> 해당 내용은 노션 문서에 저장