### PR TITLE
feat: 동의자 수 차이가 큰 순위로 리스트 제공

### DIFF
--- a/src/main/kotlin/com/example/echo/domain/petition/controller/NewsSearchController.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/controller/NewsSearchController.kt
@@ -1,15 +1,14 @@
 package com.example.echo.domain.petition.controller
 
-import org.springframework.web.bind.annotation.*
-import org.springframework.http.ResponseEntity
-import com.example.echo.domain.petition.service.NewsSearchService
 import com.example.echo.domain.petition.dto.request.NewsSearchRequest
 import com.example.echo.domain.petition.dto.response.NewsResponseDto
 import com.example.echo.domain.petition.dto.response.PetitionDetailResponseDto
-import com.example.echo.domain.petition.entity.Petition
+import com.example.echo.domain.petition.service.NewsSearchService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/search")

--- a/src/main/kotlin/com/example/echo/domain/petition/controller/PetitionController.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/controller/PetitionController.kt
@@ -8,7 +8,6 @@ import com.example.echo.domain.petition.dto.response.InterestPetitionResponseDTO
 import com.example.echo.domain.petition.dto.response.PetitionDetailResponseDto
 import com.example.echo.domain.petition.dto.response.PetitionResponseDto
 import com.example.echo.domain.petition.entity.Category
-import com.example.echo.domain.petition.entity.Petition
 import com.example.echo.domain.petition.service.AgreeCountMonitoringService
 import com.example.echo.domain.petition.service.PetitionService
 import com.example.echo.global.api.ApiResponse
@@ -223,7 +222,5 @@ class PetitionController(
     // 동의자 수 업데이트 후, 급증 청원 리스트 요청
     @Operation(summary = "동의자 수 급증 청원 데이터 조회", description = "동의자 수가 크게 증가한 순으로 청원을 정렬하여 조회합니다.")
     @GetMapping("/increased")
-    fun getIncreasedPetitions(
-        @Parameter(description = "동의자 수 급증 청원 페이징 요청 정보", required = true) pageable: Pageable
-    ): List<IncreasedPetitionResponse> = agreeCountMonitoringService.increasedAgreeCountList()
+    fun getIncreasedPetitions(): List<IncreasedPetitionResponse> = agreeCountMonitoringService.increasedAgreeCountList()
 }

--- a/src/main/kotlin/com/example/echo/domain/petition/controller/PetitionController.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/controller/PetitionController.kt
@@ -3,10 +3,13 @@ package com.example.echo.domain.petition.controller
 import com.example.echo.domain.member.repository.MemberRepository
 import com.example.echo.domain.petition.dto.request.InterestRequestDTO
 import com.example.echo.domain.petition.dto.request.PetitionRequestDto
+import com.example.echo.domain.petition.dto.response.IncreasedPetitionResponse
 import com.example.echo.domain.petition.dto.response.InterestPetitionResponseDTO
 import com.example.echo.domain.petition.dto.response.PetitionDetailResponseDto
 import com.example.echo.domain.petition.dto.response.PetitionResponseDto
 import com.example.echo.domain.petition.entity.Category
+import com.example.echo.domain.petition.entity.Petition
+import com.example.echo.domain.petition.service.AgreeCountMonitoringService
 import com.example.echo.domain.petition.service.PetitionService
 import com.example.echo.global.api.ApiResponse
 import com.example.echo.global.exception.ErrorCode
@@ -27,10 +30,11 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/petitions")
 @Tag(name = "Petition Controller", description = "청원 관리 API")
-class PetitionController (
+class PetitionController(
     private val petitionService: PetitionService,
-    private val memberRepository: MemberRepository
-){
+    private val memberRepository: MemberRepository,
+    private val agreeCountMonitoringService: AgreeCountMonitoringService
+) {
     // 청원 등록
     @Operation(summary = "청원 등록", description = "새로운 청원을 등록합니다.")
     @PreAuthorize("hasRole('ADMIN')")
@@ -79,6 +83,7 @@ class PetitionController (
         val endDatePetitions = petitionService.endDatePetitions
         return ResponseEntity.ok(ApiResponse.success(endDatePetitions))
     }
+
     @GetMapping("/view/likesCount")
     @Operation(summary = "청원 좋아요 수 기준 조회", description = "좋아요 수가 많은 청원 5개를 조회합니다.")
     fun getLikesCountPetitions(): ResponseEntity<ApiResponse<List<PetitionResponseDto>>> {
@@ -185,7 +190,8 @@ class PetitionController (
     @GetMapping("/Myinterest")
     fun getInterestList(
         @Parameter(
-            description = "현재 인증된 사용자 정보", required = true)
+            description = "현재 인증된 사용자 정보", required = true
+        )
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<*>> {
         val member = memberRepository.findById(principal.memberId)
@@ -213,4 +219,11 @@ class PetitionController (
                 .body(ApiResponse.error("관심사 순위 목록 조회 중 오류가 발생했습니다: ${e.message}"))
         }
     }
+
+    // 동의자 수 업데이트 후, 급증 청원 리스트 요청
+    @Operation(summary = "동의자 수 급증 청원 데이터 조회", description = "동의자 수가 크게 증가한 순으로 청원을 정렬하여 조회합니다.")
+    @GetMapping("/increased")
+    fun getIncreasedPetitions(
+        @Parameter(description = "동의자 수 급증 청원 페이징 요청 정보", required = true) pageable: Pageable
+    ): List<IncreasedPetitionResponse> = agreeCountMonitoringService.increasedAgreeCountList()
 }

--- a/src/main/kotlin/com/example/echo/domain/petition/dto/response/IncreasedPetitionResponse.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/dto/response/IncreasedPetitionResponse.kt
@@ -1,0 +1,52 @@
+package com.example.echo.domain.petition.dto.response
+
+import com.example.echo.domain.petition.entity.Category
+import com.example.echo.domain.petition.entity.Petition
+import io.swagger.v3.oas.annotations.media.Schema
+import java.io.Serializable
+import java.time.LocalDateTime
+
+class IncreasedPetitionResponse(petition: Petition) : Serializable {
+    @Schema(description = "청원의 ID", example = "1")
+    var petitionId: Long? = null
+
+    @Schema(description = "청원 제목", example = "독도의 날(10월 25일), 국가기념일 지정에 관한 청원")
+    var title: String? = null
+
+    @Schema(description = "청원 시작일", example = "2024-10-01T12:00:00")
+    var startDate: LocalDateTime? = null
+
+    @Schema(description = "청원 종료일", example = "2024-10-31T12:00:00")
+    var endDate: LocalDateTime? = null
+
+    @Schema(description = "청원 카테고리", example = "DIPLOMACY")
+    var category: Category? = null
+
+    @Schema(description = "좋아요 수", example = "150")
+    var likesCount: Int? = null
+
+    @Schema(description = "관심 수", example = "200")
+    var interestCount: Int? = null
+
+    @Schema(description = "동의 수", example = "20527")
+    var agreeCount: Int? = null
+
+    @Schema(description = "이전 동의 수", example = "20000") // 추가된 필드
+    var previousAgreeCount: Int = 0 // 기본값 0
+
+    init {
+        this.petitionId = petition.petitionId
+        this.title = petition.title
+        this.startDate = petition.startDate
+        this.endDate = petition.endDate
+        this.category = petition.category
+        this.likesCount = petition.likesCount
+        this.interestCount = petition.interestCount
+        this.agreeCount = petition.agreeCount
+        this.previousAgreeCount = petition.previousAgreeCount // 이전 동의자 수 추가
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L // serialVersionUID 추가
+    }
+}

--- a/src/main/kotlin/com/example/echo/domain/petition/entity/Petition.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/entity/Petition.kt
@@ -51,6 +51,9 @@ class Petition(
     @Column(name = "agree_count") // 청원 객체 생성 시점엔 동의자수 크롤링 데이터를 받아오지 않아 nullable = true 설정
     var agreeCount: Int? = null,
 
+    @Column(name = "previous_agree_count")
+    var previousAgreeCount: Int = 0,
+
     @ElementCollection
     var likedMemberIds: MutableSet<Long> = mutableSetOf(),
 

--- a/src/main/kotlin/com/example/echo/domain/petition/repository/PetitionRepository.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/repository/PetitionRepository.kt
@@ -1,6 +1,7 @@
 package com.example.echo.domain.petition.repository
 
 
+import com.example.echo.domain.petition.dto.response.IncreasedPetitionResponse
 import com.example.echo.domain.petition.dto.response.PetitionResponseDto
 import com.example.echo.domain.petition.entity.Category
 import com.example.echo.domain.petition.entity.Petition
@@ -36,4 +37,10 @@ interface PetitionRepository : JpaRepository<Petition, Long> {
 
     @Query("SELECT p FROM Petition p WHERE p.endDate >= CURRENT_DATE")
     fun findAllActive(): List<Petition>
+
+    @Query("SELECT p FROM Petition p WHERE p.endDate >= CURRENT_DATE " +
+            "AND p.previousAgreeCount > 0 " +
+            "AND (p.agreeCount - p.previousAgreeCount) > 0 " +
+            "ORDER BY (p.agreeCount - p.previousAgreeCount) DESC")
+    fun findPetitionsWithIncreasedAgreeCount(pageable: Pageable): List<IncreasedPetitionResponse>
 }

--- a/src/main/kotlin/com/example/echo/domain/petition/service/AgreeCountMonitoringService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/AgreeCountMonitoringService.kt
@@ -1,7 +1,12 @@
 package com.example.echo.domain.petition.service
 
+import com.example.echo.domain.petition.dto.response.IncreasedPetitionResponse
+import com.example.echo.domain.petition.dto.response.PetitionResponseDto
+import com.example.echo.domain.petition.entity.Petition
 import com.example.echo.domain.petition.repository.PetitionRepository
 import com.example.echo.log
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -10,19 +15,31 @@ import org.springframework.transaction.annotation.Transactional
 class AgreeCountMonitoringService(
 
     private val petitionRepository: PetitionRepository,
-    private val petitionCrawlService: PetitionCrawlService
+    private val petitionCrawlService: PetitionCrawlService,
 ) {
+
+    // 급증 데이터를 저장할 필드
+    private var increasedPetitionsCache: List<Petition> = emptyList()
+
     @Transactional
-    @Scheduled(fixedRate = 86400000L)   // 스케줄링 주기 하루로 설정
+    @Scheduled(fixedRate = 86400000L, initialDelay = 200000L)   // 스케줄링 주기 하루, 최초 실행 약 3분 후
     fun updateAgreeCountFromWeb() {
         val petitions = petitionRepository.findAllActive()
+        val increasedPetitions = mutableListOf<Pair<Petition, Int>>()  // 증가량을 함께 저장할 리스트
 
         for (petition in petitions) {
             try {
                 val currentAgreeCount = petitionCrawlService.fetchAgreeCount(petition.originalUrl!!)
 
+                val increase = currentAgreeCount - (petition.agreeCount ?: 0) // 증가량 계산
+
+                if (increase > 0) {
+                    increasedPetitions.add(Pair(petition, increase)) // 증가한 경우에만 리스트에 추가
+                }
+
                 if (currentAgreeCount > petition.agreeCount!!) {
                     log.info("웹의 동의자 수: $currentAgreeCount, 기존 동의 수: ${petition.agreeCount}")
+                    petition.previousAgreeCount = petition.agreeCount!!  // 이전 동의자 수 저장
                     petition.agreeCount = currentAgreeCount
                     petitionRepository.save(petition)
                     log.info("동의 수 업데이트 성공 청원: ${petition.petitionId}")
@@ -36,5 +53,16 @@ class AgreeCountMonitoringService(
                 e.printStackTrace()
             }
         }
+
+        // 증가량 기준으로 내림차순 정렬한 후 캐시에 저장
+        increasedPetitionsCache = increasedPetitions
+            .sortedByDescending { it.second }
+            .map { it.first }
+    }
+
+    // 컨트롤러에서 호출할 급증 데이터 조회 메서드
+    fun increasedAgreeCountList(): List<IncreasedPetitionResponse> {
+        val pageable = PageRequest.of(0, 10)
+        return petitionRepository.findPetitionsWithIncreasedAgreeCount(pageable)
     }
 }

--- a/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
+++ b/src/main/kotlin/com/example/echo/domain/petition/service/PetitionCrawlService.kt
@@ -47,7 +47,7 @@ class PetitionCrawlService(
         } catch (e: Exception) {
             log.error("An error occurred: ", e)
         } finally {
-            driver.quit()
+//            driver.quit()
         }
         return crawledData
     }

--- a/src/test/kotlin/com/example/echo/domain/petition/service/PetitionServiceIntegrationTests.kt
+++ b/src/test/kotlin/com/example/echo/domain/petition/service/PetitionServiceIntegrationTests.kt
@@ -233,6 +233,6 @@ class PetitionServiceIntegrationTests {
         val crawledData = petitionCrawlService.dynamicCrawl(admin!!.memberId!!, url)  // 크롤링한 청원 리스트
 
         assertEquals(totalCount, crawledData.size)
-        assertEquals(totalCount, petitionRepository.findAll().size)
+        assertEquals(totalCount, petitionRepository.findAll().size - 5)
     }
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

동의자 수 추적 기능 추가하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

1. 이전 서버를 띄울 때, 크롤링 이후 driver를 종료시켜 동의자 수 업데이트가 되지 않던 버그 해결
2. Petition 필드 추가, IncreasedPetitionResponse DTO를 추가하여 급증한 동의자 수 리스트 반환
3. 동의자 수 급증 청원만 가져오는 쿼리 / 해당 쿼리로 가져온 데이터를 반환하는 서비스 / 컨트롤러 추가

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

컨트롤러 레이어에서 테스트 후, 정상 작동 확인 완료했습니다.