### PR TITLE
refactor: FileControllerAdvice에서 GlobalControllerAdvice로 수정

### DIFF
--- a/src/main/kotlin/com/example/echo/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/echo/global/exception/ErrorCode.kt
@@ -42,4 +42,9 @@ enum class ErrorCode(
     INVALID_UPLOAD_PATH(INTERNAL_SERVER_ERROR, "업로드 경로가 올바르지 않습니다."),
     FILE_SIZE_LIMIT_EXCEEDED(BAD_REQUEST, "파일 크기 제한을 초과했습니다."),
     FILE_NOT_FOUND(NOT_FOUND, "파일을 찾을 수 없습니다."),
+
+    // Global
+    INVALID_ARGUMENT(BAD_REQUEST, "입력 값이 유효하지 않습니다."),
+    ACCESS_DENIED(FORBIDDEN, "해당 요청에 대한 권한이 부족하여 접근이 거부되었습니다.");
+
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

기존의 Exception 불명확하게 예외를 처리하던 FileControllerAdvice를 GlobalControllerAdvice로 변경

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- 기존 MemberController 내에 있던 advice 패키지를 global 패키지로 변경
- AuthorizationDeniedException에 대한 핸들링 메서드 추가

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

- 이후에도 추가되는 특정 xxxException이 있다면 GlobalControllerAdvice 내에 handlexxxException 이런 식으로 핸들링 메서드를 추가해주세요!